### PR TITLE
Rank check fixes

### DIFF
--- a/NightgamesMod/nightgames/characters/Growth.java
+++ b/NightgamesMod/nightgames/characters/Growth.java
@@ -57,11 +57,7 @@ public class Growth {
         character.getMojo().gain(mojo);
         character.getWillpower().gain(willpower);
 
-        if (character.rank < attributes.length) {
-            character.availableAttributePoints += attributes[character.rank];
-        } else {
-            character.availableAttributePoints += attributes[attributes.length - 1];
-        }
+        character.availableAttributePoints += attributes[Math.min(character.rank, attributes.length-1)];
 
         if (Global.checkFlag(Flag.hardmode)) {
             character.getStamina().gain(bonusStamina);

--- a/NightgamesMod/nightgames/characters/Player.java
+++ b/NightgamesMod/nightgames/characters/Player.java
@@ -414,7 +414,7 @@ public class Player extends Character {
         status.removeIf(s -> !s.isAddiction());
         stamina.fill();
         if (location.name.equals("Showers")) {
-            gui.message("You let the hot water wash away your exhaustion and soon you're back to peak condition");
+            gui.message("You let the hot water wash away your exhaustion and soon you're back to peak condition.");
         }
         if (location.name.equals("Pool")) {
             gui.message("The hot water soothes and relaxes your muscles. You feel a bit exposed, skinny-dipping in such an open area. You decide it's time to get moving.");

--- a/NightgamesMod/nightgames/characters/Player.java
+++ b/NightgamesMod/nightgames/characters/Player.java
@@ -382,7 +382,7 @@ public class Player extends Character {
         getStamina().gain(growth.stamina);
         getArousal().gain(growth.arousal);
         getMojo().gain(growth.mojo);
-        availableAttributePoints += growth.attributes[rank];
+        availableAttributePoints += growth.attributes[Math.min(rank, growth.attributes.length-1)];
         getMojo().gain(1);
         gui.message("You've gained a Level!<br>Select which attributes to increase.");
         if (getLevel() % 3 == 0 && level < 10 || (getLevel() + 1) % 2 == 0 && level > 10) {

--- a/NightgamesMod/nightgames/skills/Anilingus.java
+++ b/NightgamesMod/nightgames/skills/Anilingus.java
@@ -125,15 +125,15 @@ public class Anilingus extends Skill {
     @Override
     public String receive(Combat c, int damage, Result modifier, Character target) {
         if (modifier == Result.miss) {
-            return getSelf().name() + " closes in on your behind, but you manage to push "+target.possessivePronoun()+" head away.";
+            return getSelf().name() + " closes in on your behind, but you manage to push "+getSelf().possessivePronoun()+" head away.";
         } else if (modifier == Result.special) {
-            return getSelf().name() + " gently rims your asshole with "+target.possessivePronoun()+" tongue, sending shivers through your body.";
+            return getSelf().name() + " gently rims your asshole with "+getSelf().possessivePronoun()+" tongue, sending shivers through your body.";
         } else if (modifier == Result.reverse) {
             return "With your ass pressing into " + getSelf().nameOrPossessivePronoun()
-                            + " face, "+target.pronoun()+" helplessly gives in and starts licking your ass.";
+                            + " face, "+getSelf().pronoun()+" helplessly gives in and starts licking your ass.";
         } else if (modifier == Result.sub) {
             return "As if entranced, " + getSelf().subject()
-                            + " buries "+target.possessivePronoun()+" face inside your ass cheeks, licking your crack, and worshipping your anus.";
+                            + " buries "+getSelf().possessivePronoun()+" face inside your ass cheeks, licking your crack, and worshipping your anus.";
         }
         return getSelf().name() + " licks your tight asshole, both surprising and arousing you.";
     }

--- a/NightgamesMod/nightgames/skills/Anilingus.java
+++ b/NightgamesMod/nightgames/skills/Anilingus.java
@@ -105,35 +105,35 @@ public class Anilingus extends Skill {
     @Override
     public String deal(Combat c, int damage, Result modifier, Character target) {
         if (modifier == Result.miss) {
-            return "You try to lick " + target.name() + "'s rosebud, but she pushes your head away.";
+            return "You try to lick " + target.name() + "'s rosebud, but "+target.pronoun()+" pushes your head away.";
         } else if (modifier == Result.special) {
-            return "You gently rim " + target.name() + "'s asshole with your tongue, sending shivers through her body.";
+            return "You gently rim " + target.name() + "'s asshole with your tongue, sending shivers through "+target.possessivePronoun()+" body.";
         } else if (modifier == Result.reverse) {
             return "With " + target.nameOrPossessivePronoun()
-                            + " ass pressing into your face, you helplessly give in and take an experimental lick at her pucker.";
+                            + " ass pressing into your face, you helplessly give in and take an experimental lick at "+target.possessivePronoun()+" pucker.";
         } else if (modifier == Result.sub) {
             return "With a terrible need coursing through you, you lower your face between "
                             + target.nameOrPossessivePronoun()
-                            + " rear cheeks and plunge your tongue repeatedly in and out of her "
+                            + " rear cheeks and plunge your tongue repeatedly in and out of "+target.possessivePronoun()+" "
                             + target.body.getRandom("ass").describe(target) + ". "
                             + "You dimly realize that this is probably arousing you as much as " + target.getName()
-                            + ", but worshipping her sublime derriere seems much higher on your priorities than winning.";
+                            + ", but worshipping "+target.possessivePronoun()+" sublime derriere seems much higher on your priorities than winning.";
         }
-        return "You thrust your tongue into " + target.name() + "'s ass and lick it, making her yelp in surprise.";
+        return "You thrust your tongue into " + target.name() + "'s ass and lick it, making "+target.directObject()+" yelp in surprise.";
     }
 
     @Override
     public String receive(Combat c, int damage, Result modifier, Character target) {
         if (modifier == Result.miss) {
-            return getSelf().name() + " closes in on your behind, but you manage to push her head away.";
+            return getSelf().name() + " closes in on your behind, but you manage to push "+target.possessivePronoun()+" head away.";
         } else if (modifier == Result.special) {
-            return getSelf().name() + " gently rims your asshole with her tongue, sending shivers through your body.";
+            return getSelf().name() + " gently rims your asshole with "+target.possessivePronoun()+" tongue, sending shivers through your body.";
         } else if (modifier == Result.reverse) {
             return "With your ass pressing into " + getSelf().nameOrPossessivePronoun()
-                            + " face, she helplessly gives in and starts licking your ass.";
+                            + " face, "+target.pronoun()+" helplessly gives in and starts licking your ass.";
         } else if (modifier == Result.sub) {
             return "As if entranced, " + getSelf().subject()
-                            + " buries her face inside your ass cheeks, licking your crack, and worshipping your anus.";
+                            + " buries "+target.possessivePronoun()+" face inside your ass cheeks, licking your crack, and worshipping your anus.";
         }
         return getSelf().name() + " licks your tight asshole, both surprising and arousing you.";
     }

--- a/NightgamesMod/nightgames/skills/Aphrodisiac.java
+++ b/NightgamesMod/nightgames/skills/Aphrodisiac.java
@@ -90,11 +90,12 @@ public class Aphrodisiac extends Skill {
     @Override
     public String deal(Combat c, int damage, Result modifier, Character target) {
         if (modifier == Result.special) {
-            return "You pop an Aphrodisiac into your Aerosolizer and spray " + target.name()
-                            + " with a cloud of mist. She flushes and her eyes fill with lust as it takes hold.";
+            return String.format("You pop an Aphrodisiac into your Aerosolizer and spray %s"
+                            + " with a cloud of mist. %s flushes and %s eyes fill with lust as it takes hold.", 
+                            target.name(), Global.capitalizeFirstLetter(target.pronoun()), target.possessivePronoun());
         } else if (modifier == Result.miss) {
             return "You throw an Aphrodisiac at " + target.name()
-                            + ", but she ducks out of the way and it splashes harmlessly on the ground. What a waste.";
+                            + ", but "+target.pronoun()+" ducks out of the way and it splashes harmlessly on the ground. What a waste.";
         } else if (modifier == Result.strong) {
             return getSelf().subjectAction("dip", "dips") + " a finger "
                             + (getSelf().crotchAvailable() ? ""
@@ -109,12 +110,12 @@ public class Aphrodisiac extends Skill {
                             + target.directObject() + "," + " skillfully depositing it in " + target.possessivePronoun()
                             + " open mouth. " + Global.capitalizeFirstLetter(target.subject()) + " immediately feel"
                             + " a flash of heat spread through " + target.directObject()
-                            + " and only a small part of it" + " results from the anger caused by "
+                            + " and only a small part of it results from the anger caused by "
                             + getSelf().possessivePronoun() + " dirty move.";
         } else {
             return "You uncap a small bottle of Aphrodisiac and splash it in " + target.name()
-                            + "'s face. For a second, she's just surprised, but gradually a growing desire "
-                            + "starts to make her weak in the knees.";
+                            + "'s face. For a second, "+target.possessivePronoun()+"'s just surprised, but gradually a growing desire "
+                            + "starts to make "+target.directObject()+" weak in the knees.";
         }
 
     }
@@ -126,8 +127,8 @@ public class Aphrodisiac extends Skill {
                             + target.nameOrPossessivePronoun() + " direction, but none of it hits you.";
         } else if (modifier == Result.special) {
             return getSelf().name()
-                            + " inserts a bottle into the attachment on her arm. You're suddenly surrounded by a sweet smelling cloud of mist. You feel your blood boil "
-                            + "with desire as the unnatural gas takes effect";
+                            + " inserts a bottle into the attachment on "+getSelf().possessivePronoun()+" arm. You're suddenly surrounded by a sweet smelling cloud of mist. You feel your blood boil "
+                            + "with desire as the unnatural gas takes effect.";
         } else if (modifier == Result.strong) {
             return getSelf().subjectAction("dip", "dips") + " a finger "
                             + (getSelf().crotchAvailable() ? ""

--- a/NightgamesMod/nightgames/skills/ArmBar.java
+++ b/NightgamesMod/nightgames/skills/ArmBar.java
@@ -67,7 +67,7 @@ public class ArmBar extends Skill {
     @Override
     public String deal(Combat c, int damage, Result modifier, Character target) {
         if (modifier == Result.miss) {
-            return "You grab at " + target.name() + "'s arm, but she pulls it free.";
+            return "You grab at " + target.name() + "'s arm, but "+target.pronoun()+" pulls it free.";
         } else {
             return "You grab " + target.name()
                             + "'s arm at the wrist and pull it to your chest in the traditional judo submission technique.";
@@ -77,11 +77,11 @@ public class ArmBar extends Skill {
     @Override
     public String receive(Combat c, int damage, Result modifier, Character target) {
         if (modifier == Result.miss) {
-            return getSelf().name() + " grabs your wrist, but you pry it out of her grasp.";
+            return getSelf().name() + " grabs your wrist, but you pry it out of "+getSelf().possessivePronoun()+" grasp.";
         } else {
             return getSelf().name()
-                            + " pulls your arm between her legs, forcibly overextending your elbow. The pain almost makes you tap out, but you manage to yank your arm "
-                            + "out of her grip.";
+                            + " pulls your arm between "+getSelf().possessivePronoun()+" legs, forcibly overextending your elbow. The pain almost makes you tap out, but you manage to yank your arm "
+                            + "out of "+getSelf().possessivePronoun()+" grip.";
         }
     }
 

--- a/NightgamesMod/nightgames/skills/AssFuck.java
+++ b/NightgamesMod/nightgames/skills/AssFuck.java
@@ -146,11 +146,11 @@ public class AssFuck extends Fuck {
         if (modifier == Result.normal) {
             return String.format(
                             (damage == 0 ? "You" : "After you")
-                                            + " make sure %s ass is sufficiently lubricated, you push your %s into her %s.",
+                                            + " make sure %s ass is sufficiently lubricated, you push your %s into %s %s.",
                             target.nameOrPossessivePronoun(), getSelfOrgan().describe(getSelf()),
-                            getTargetOrgan(target).describe(target));
+                            target.possessivePronoun(), getTargetOrgan(target).describe(target));
         } else {
-            return target.name() + "'s ass is oiled up and ready to go, but you're still too soft to penetrate her.";
+            return target.name() + "'s ass is oiled up and ready to go, but you're still too soft to penetrate "+target.directObject()+".";
         }
     }
 

--- a/NightgamesMod/nightgames/skills/Blindside.java
+++ b/NightgamesMod/nightgames/skills/Blindside.java
@@ -41,7 +41,7 @@ public class Blindside extends Skill {
             c.write(getSelf(),
                             String.format("You move up to %s and kiss %s strongly. "
                                             + "While %s is distracted, you throw %s down and plant "
-                                            + "yourself on top of %s.", target.name(), target.pronoun(),
+                                            + "yourself on top of %s.", target.name(), target.directObject(),
                             target.pronoun(), target.directObject(), target.directObject()));
         } else {
             c.write(getSelf(), "Seductively swaying her hips, " + getSelf().subject() + " shashays over to you. "

--- a/NightgamesMod/nightgames/skills/Bravado.java
+++ b/NightgamesMod/nightgames/skills/Bravado.java
@@ -65,7 +65,7 @@ public class Bravado extends Skill {
 
     @Override
     public String receive(Combat c, int damage, Result modifier, Character attacker) {
-        return getSelf().name() + " gives you a determined glare as she seems to gain a second wind.";
+        return getSelf().name() + " gives you a determined glare as " + getSelf().pronoun() + " seems to gain a second wind.";
     }
 
     @Override

--- a/NightgamesMod/nightgames/skills/Fuck.java
+++ b/NightgamesMod/nightgames/skills/Fuck.java
@@ -182,23 +182,23 @@ public class Fuck extends Skill {
         BodyPart targetO = getTargetOrgan(target);
         if (modifier == Result.normal) {
             return "you rub the head of your " + selfO.describe(getSelf()) + " around " + target.name()
-                            + "'s entrance, causing her to shiver with anticipation. Once you're sufficiently lubricated "
-                            + "with her wetness, you thrust into her " + target.body.getRandomPussy().describe(target)
+                            + "'s entrance, causing "+target.directObject()+" to shiver with anticipation. Once you're sufficiently lubricated "
+                            + "with "+target.possessivePronoun()+" wetness, you thrust into "+target.possessivePronoun()+" " + targetO.describe(target)
                             + ". " + target.name()
-                            + " tries to stifle her pleasured moan as you fill her in an instant.";
+                            + " tries to stifle "+target.possessivePronoun()+" pleasured moan as you fill "+target.possessivePronoun()+" in an instant.";
         } else if (modifier == Result.miss) {
             if (!selfO.isReady(getSelf()) && !targetO.isReady(target)) {
                 return "you're in a good position to fuck " + target.name()
                                 + ", but neither of you are aroused enough to follow through.";
-            } else if (!getTargetOrgan(target).isReady(target)) {
+            } else if (!targetO.isReady(target)) {
                 return "you position your " + selfO.describe(getSelf()) + " at the entrance to " + target.name()
-                                + ", but find that she's not nearly wet enough to allow a comfortable insertion. You'll need "
-                                + "to arouse her more or you'll risk hurting her.";
+                                + ", but find that "+target.pronoun()+"'s not nearly wet enough to allow a comfortable insertion. You'll need "
+                                + "to arouse "+target.directObject()+" more or you'll risk hurting "+target.directObject()+".";
             } else if (!selfO.isReady(getSelf())) {
                 return "you're ready and willing to claim " + target.name() + "'s eager "
-                                + target.body.getRandomPussy().describe(target) + ", but your shriveled "
+                                + targetO.describe(target) + ", but your shriveled "
                                 + selfO.describe(getSelf())
-                                + " isn't cooperating. Maybe your self-control training has become " + "too effective.";
+                                + " isn't cooperating. Maybe your self-control training has become too effective.";
             }
             return "you managed to miss the mark.";
         }
@@ -210,10 +210,10 @@ public class Fuck extends Skill {
         BodyPart selfO = getSelfOrgan();
         BodyPart targetO = getTargetOrgan(target);
         if (modifier == Result.normal) {
-            String message = getSelf().name() + " rubs her " + selfO.describe(getSelf())
-                            + " against your wet snatch. She slowly but steadily pushes in, forcing "
-                            + "her length into your hot, wet pussy.";
-            return message;
+            return String.format("%s rubs %s %s against your wet snatch. " +
+                                 "%s slowly but steadily pushes in, forcing %s length into your hot, wet pussy.", 
+                            getSelf().name(), getSelf().possessivePronoun(), selfO.describe(getSelf()), 
+                            Global.capitalizeFirstLetter(getSelf().pronoun()), getSelf().possessivePronoun());
         } else if (modifier == Result.miss) {
             if (!selfO.isReady(getSelf()) || !targetO.isReady(target)) {
                 return (damage == 0 ? getSelf().name() + " " : "")

--- a/NightgamesMod/nightgames/skills/Slap.java
+++ b/NightgamesMod/nightgames/skills/Slap.java
@@ -131,7 +131,7 @@ public class Slap extends Skill {
         if (modifier == Result.miss) {
             return target.name() + " avoids your slap.";
         } else if (modifier == Result.special) {
-            return "You channel your bestial power and strike" + target.name() + " with a solid open hand strike.";
+            return "You channel your bestial power and strike " + target.name() + " with a solid open hand strike.";
         } else if (modifier == Result.critical) {
             return "You let more of your slime flow to your hand, tripling it in size. Then, you lash out and slam "
                             + target.name() + " in the face.";

--- a/NightgamesMod/nightgames/skills/Spank.java
+++ b/NightgamesMod/nightgames/skills/Spank.java
@@ -84,13 +84,13 @@ public class Spank extends Skill {
     @Override
     public String deal(Combat c, int damage, Result modifier, Character target) {
         if (modifier == Result.miss) {
-            return "You try to spank " + target.name() + ", but she dodges away.";
+            return "You try to spank " + target.name() + ", but "+target.pronoun()+" dodges away.";
         }
         if (modifier == Result.special) {
             return "You bend " + target.name()
-                            + " over your knee and spank her, alternating between hitting her soft butt cheek and her sensitive pussy.";
+                            + " over your knee and spank "+target.directObject()+", alternating between hitting "+target.possessivePronoun()+" soft butt cheek and "+target.possessivePronoun()+" sensitive pussy.";
         } else {
-            return "You spank " + target.name() + " on her naked butt cheek.";
+            return "You spank " + target.name() + " on "+target.possessivePronoun()+" naked butt cheek.";
         }
 
     }

--- a/NightgamesMod/nightgames/stance/Standing.java
+++ b/NightgamesMod/nightgames/stance/Standing.java
@@ -12,7 +12,7 @@ public class Standing extends MaledomSexStance {
     @Override
     public String describe() {
         if (top.human()) {
-            return "You are holding " + bottom.name() + " in the air while buried deep in her pussy";
+            return "You are holding " + bottom.name() + " in the air while buried deep in her pussy.";
         } else {
             return top.name() + " is holding you in her arms while pumping into your girl parts.";
         }


### PR DESCRIPTION
also includes two period fixes - one for showering and one for a combat stance
Actually it's a lot of fixes again as I keep adding stuff to it... I ended up "genderifying" several skills, meaning they now do both him/her. Should be safe to merge; if it ends up being grammatically invalid somehow, I'll fix it later in another bulk fix? I tested most of them.
